### PR TITLE
no update is also returns success [Test Sandro, do not merge or edit]

### DIFF
--- a/update_version.scp
+++ b/update_version.scp
@@ -30,7 +30,7 @@ if [[ $LATEST_COMMIT_MESSAGE == *"Update Version"* ]]; then
     echo "Start Version Update"
 else
     echo "Do not update the version"
-    exit 1
+    exit 0
 fi
 
 # Get the first argument that is given to this script. 


### PR DESCRIPTION
Since not updating the version number if the commit does not contain the keyword is intended behavior I would suggest it to return a successful operation. This way the test only fails if a "real" error happens. Furthermore github would always show an ❌ for a PR even if all other tests pass. Only the version update commit would get a ✅